### PR TITLE
Update all composer workflows

### DIFF
--- a/.github/workflows/Chibi_ci_build.yml
+++ b/.github/workflows/Chibi_ci_build.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add --no-cache musl-dev gcc vips-dev python3-dev zip py3-pip py3-wheel
+          apk add --no-cache musl-dev gcc vips-dev python3-dev py3-pip py3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
@@ -59,26 +59,24 @@ jobs:
       - name: Build
         id: build
         run: |
-          mkdir build && cd build
-          wget -q https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          mkdir build
+          wget -q -P build https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
           || echo "Error: Failed to get compose.py"
 
-          cd ..
-          python3 build/compose.py --use-all gfx/Chibi_Ultica
-          cd build
+          python3 build/compose.py --use-all gfx/Chibi_Ultica build
 
-          artifact_name=Chibi_Ultica-$(echo $GITHUB_SHA | cut -c -8)
-          tileset_dir=../gfx/Chibi_Ultica
+          artifact_name=Chibi_Ultica-${GITHUB_SHA::7}
+          tileset_dir=build
 
-          mkdir $artifact_name
-          mv $tileset_dir/*.png            $artifact_name
-          mv $tileset_dir/tile_config.json $artifact_name
-          mv $tileset_dir/tileset.txt      $artifact_name
+          mkdir "$artifact_name"
+          mv $tileset_dir/*.png              "$artifact_name"
+          mv $tileset_dir/tile_config.json   "$artifact_name"
+          mv gfx/Chibi_Ultica/tileset.txt    "$artifact_name"
 
-          echo ::set-output name=artifact_name::$artifact_name
+          echo ::set-output name=artifact_name::"$artifact_name"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.build.outputs.artifact_name }}
-          path: build/${{ steps.build.outputs.artifact_name }}
+          path: ${{ steps.build.outputs.artifact_name }}

--- a/.github/workflows/HitButton_ci_build.yml
+++ b/.github/workflows/HitButton_ci_build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add --no-cache musl-dev gcc vips-dev python3-dev zip py3-pip py3-wheel
+          apk add --no-cache musl-dev gcc vips-dev python3-dev py3-pip py3-wheel
           pip3 install pyvips
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -36,21 +36,24 @@ jobs:
       - name: Build
         id: build
         run: |
-          mkdir build && cd build
-          wget -q https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          mkdir build
+          wget -q -P build https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
           || echo "Error: Failed to get compose.py"
-          cd ..
-          python3 build/compose.py --use-all gfx/HitButton_iso
-          cd build
-          artifact_name=HitButton-$(echo $GITHUB_SHA | cut -c -8)
-          tileset_dir=../gfx/HitButton_iso
-          mkdir $artifact_name
-          mv $tileset_dir/*.png            $artifact_name
-          mv $tileset_dir/tile_config.json $artifact_name
-          mv $tileset_dir/tileset.txt      $artifact_name
-          echo ::set-output name=artifact_name::$artifact_name
+
+          python3 build/compose.py --use-all gfx/HitButton_iso build
+
+          artifact_name=HitButton-${GITHUB_SHA::7}
+          tileset_dir=build
+
+          mkdir "$artifact_name"
+          mv $tileset_dir/*.png              "$artifact_name"
+          mv $tileset_dir/tile_config.json   "$artifact_name"
+          mv gfx/HitButton_iso/tileset.txt   "$artifact_name"
+
+          echo ::set-output name=artifact_name::"$artifact_name"
+
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.build.outputs.artifact_name }}
-          path: build/${{ steps.build.outputs.artifact_name }}
+          path: ${{ steps.build.outputs.artifact_name }}

--- a/.github/workflows/MD_ci_build.yml
+++ b/.github/workflows/MD_ci_build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add --no-cache musl-dev gcc vips-dev python3-dev zip py3-pip py3-wheel
+          apk add --no-cache musl-dev gcc vips-dev python3-dev py3-pip py3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
@@ -37,26 +37,24 @@ jobs:
       - name: Build
         id: build
         run: |
-          mkdir build && cd build
-          wget -q https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          mkdir build
+          wget -q -P build https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
           || echo "Error: Failed to get compose.py"
 
-          cd ..
-          python3 build/compose.py --use-all --obsolete-fillers gfx/Mushroom-Dream
-          cd build
+          python3 build/compose.py --use-all --obsolete-fillers gfx/Mushroom-Dream build
 
-          artifact_name=Mushroom-Dream-$(echo $GITHUB_SHA | cut -c -8)
-          tileset_dir=../gfx/Mushroom-Dream
+          artifact_name=Mushroom-Dream-${GITHUB_SHA::7}
+          tileset_dir=build
 
-          mkdir $artifact_name
-          mv $tileset_dir/*.png            $artifact_name
-          mv $tileset_dir/tile_config.json $artifact_name
-          mv $tileset_dir/tileset.txt      $artifact_name
+          mkdir "$artifact_name"
+          mv $tileset_dir/*.png               "$artifact_name"
+          mv $tileset_dir/tile_config.json    "$artifact_name"
+          mv gfx/Mushroom-Dream/tileset.txt   "$artifact_name"
 
-          echo ::set-output name=artifact_name::$artifact_name
+          echo ::set-output name=artifact_name::"$artifact_name"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.build.outputs.artifact_name }}
-          path: build/${{ steps.build.outputs.artifact_name }}
+          path: ${{ steps.build.outputs.artifact_name }}

--- a/.github/workflows/Neodays_ci_build.yml
+++ b/.github/workflows/Neodays_ci_build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add --no-cache musl-dev gcc vips-dev python3-dev zip py3-pip py3-wheel
+          apk add --no-cache musl-dev gcc vips-dev python3-dev py3-pip py3-wheel
           pip3 install pyvips
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -36,21 +36,24 @@ jobs:
       - name: Build
         id: build
         run: |
-          mkdir build && cd build
-          wget -q https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          mkdir build
+          wget -q -P build https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
           || echo "Error: Failed to get compose.py"
-          cd ..
-          python3 build/compose.py --use-all gfx/NeoDays
-          cd build
-          artifact_name=NeoDays-$(echo $GITHUB_SHA | cut -c -8)
-          tileset_dir=../gfx/NeoDays
-          mkdir $artifact_name
-          mv $tileset_dir/*.png            $artifact_name
-          mv $tileset_dir/tile_config.json $artifact_name
-          mv $tileset_dir/tileset.txt      $artifact_name
-          echo ::set-output name=artifact_name::$artifact_name
+
+          python3 build/compose.py --use-all gfx/NeoDays build
+
+          artifact_name=NeoDays-${GITHUB_SHA::7}
+          tileset_dir=build
+
+          mkdir "$artifact_name"
+          mv $tileset_dir/*.png              "$artifact_name"
+          mv $tileset_dir/tile_config.json   "$artifact_name"
+          mv gfx/NeoDays/tileset.txt         "$artifact_name"
+
+          echo ::set-output name=artifact_name::"$artifact_name"
+
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.build.outputs.artifact_name }}
-          path: build/${{ steps.build.outputs.artifact_name }}
+          path: ${{ steps.build.outputs.artifact_name }}

--- a/.github/workflows/Retrodays_ci_build.yml
+++ b/.github/workflows/Retrodays_ci_build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add --no-cache musl-dev gcc vips-dev python3-dev zip py3-pip py3-wheel
+          apk add --no-cache musl-dev gcc vips-dev python3-dev py3-pip py3-wheel
           pip3 install pyvips
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -36,21 +36,24 @@ jobs:
       - name: Build
         id: build
         run: |
-          mkdir build && cd build
-          wget -q https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          mkdir build
+          wget -q -P build https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
           || echo "Error: Failed to get compose.py"
-          cd ..
-          python3 build/compose.py --use-all gfx/Retrodays
-          cd build
-          artifact_name=RetroDays-$(echo $GITHUB_SHA | cut -c -8)
-          tileset_dir=../gfx/Retrodays
-          mkdir $artifact_name
-          mv $tileset_dir/*.png            $artifact_name
-          mv $tileset_dir/tile_config.json $artifact_name
-          mv $tileset_dir/tileset.txt      $artifact_name
-          echo ::set-output name=artifact_name::$artifact_name
+
+          python3 build/compose.py --use-all gfx/Retrodays build
+
+          artifact_name=RetroDays-${GITHUB_SHA::7}
+          tileset_dir=build
+
+          mkdir "$artifact_name"
+          mv $tileset_dir/*.png              "$artifact_name"
+          mv $tileset_dir/tile_config.json   "$artifact_name"
+          mv gfx/Retrodays/tileset.txt       "$artifact_name"
+
+          echo ::set-output name=artifact_name::"$artifact_name"
+
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.build.outputs.artifact_name }}
-          path: build/${{ steps.build.outputs.artifact_name }}
+          path: ${{ steps.build.outputs.artifact_name }}

--- a/.github/workflows/blb_ci_build.yml
+++ b/.github/workflows/blb_ci_build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add --no-cache musl-dev gcc vips-dev python3-dev zip py3-pip py3-wheel
+          apk add --no-cache musl-dev gcc vips-dev python3-dev py3-pip py3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
@@ -37,26 +37,24 @@ jobs:
       - name: Build
         id: build
         run: |
-          mkdir build && cd build
-          wget -q https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          mkdir build
+          wget -q -P build https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
           || echo "Error: Failed to get compose.py"
 
-          cd ..
-          python3 build/compose.py --use-all --obsolete-fillers gfx/BrownLikeBears
-          cd build
+          python3 build/compose.py --use-all --obsolete-fillers gfx/BrownLikeBears build
 
-          artifact_name=BrownLikeBears-$(echo $GITHUB_SHA | cut -c -8)
-          tileset_dir=../gfx/BrownLikeBears
+          artifact_name=BrownLikeBears-${GITHUB_SHA::7}
+          tileset_dir=build
 
-          mkdir $artifact_name
-          mv $tileset_dir/*.png            $artifact_name
-          mv $tileset_dir/tile_config.json $artifact_name
-          mv $tileset_dir/tileset.txt      $artifact_name
+          mkdir "$artifact_name"
+          mv $tileset_dir/*.png               "$artifact_name"
+          mv $tileset_dir/tile_config.json    "$artifact_name"
+          mv gfx/BrownLikeBears/tileset.txt   "$artifact_name"
 
-          echo ::set-output name=artifact_name::$artifact_name
+          echo ::set-output name=artifact_name::"$artifact_name"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.build.outputs.artifact_name }}
-          path: build/${{ steps.build.outputs.artifact_name }}
+          path: ${{ steps.build.outputs.artifact_name }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add --no-cache musl-dev gcc vips-dev python3-dev zip py3-pip py3-wheel
+          apk add --no-cache musl-dev gcc vips-dev python3-dev py3-pip py3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
@@ -37,26 +37,24 @@ jobs:
       - name: Build
         id: build
         run: |
-          mkdir build && cd build
-          wget -q https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          mkdir build
+          wget -q -P build https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
           || echo "Error: Failed to get compose.py"
 
-          cd ..
-          python3 build/compose.py --use-all --obsolete-fillers gfx/UltimateCataclysm
-          cd build
+          python3 build/compose.py --use-all --obsolete-fillers gfx/UltimateCataclysm build
 
-          artifact_name=UltimateCataclysm-$(echo $GITHUB_SHA | cut -c -8)
-          tileset_dir=../gfx/UltimateCataclysm
+          artifact_name=UltimateCataclysm-${GITHUB_SHA::7}
+          tileset_dir=build
 
-          mkdir $artifact_name
-          mv $tileset_dir/*.png            $artifact_name
-          mv $tileset_dir/tile_config.json $artifact_name
-          mv $tileset_dir/tileset.txt      $artifact_name
+          mkdir "$artifact_name"
+          mv $tileset_dir/*.png                  "$artifact_name"
+          mv $tileset_dir/tile_config.json       "$artifact_name"
+          mv gfx/UltimateCataclysm/tileset.txt   "$artifact_name"
 
-          echo ::set-output name=artifact_name::$artifact_name
+          echo ::set-output name=artifact_name::"$artifact_name"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.build.outputs.artifact_name }}
-          path: build/${{ steps.build.outputs.artifact_name }}
+          path: ${{ steps.build.outputs.artifact_name }}

--- a/.github/workflows/hm_build.yml
+++ b/.github/workflows/hm_build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add --no-cache musl-dev gcc vips-dev python3-dev zip py3-pip py3-wheel
+          apk add --no-cache musl-dev gcc vips-dev python3-dev py3-pip py3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
@@ -37,26 +37,24 @@ jobs:
       - name: Build
         id: build
         run: |
-          mkdir build && cd build
-          wget -q https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          mkdir build
+          wget -q -P build https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
           || echo "Error: Failed to get compose.py"
 
-          cd ..
-          python3 build/compose.py --use-all --obsolete-fillers gfx/HollowMoon
-          cd build
+          python3 build/compose.py --use-all --obsolete-fillers gfx/HollowMoon build
 
-          artifact_name=HollowMoon-$(echo $GITHUB_SHA | cut -c -8)
-          tileset_dir=../gfx/HollowMoon
+          artifact_name=HollowMoon-${GITHUB_SHA::7}
+          tileset_dir=build
 
-          mkdir $artifact_name
-          mv $tileset_dir/*.png            $artifact_name
-          mv $tileset_dir/tile_config.json $artifact_name
-          mv $tileset_dir/tileset.txt      $artifact_name
+          mkdir "$artifact_name"
+          mv $tileset_dir/*.png              "$artifact_name"
+          mv $tileset_dir/tile_config.json   "$artifact_name"
+          mv gfx/HollowMoon/tileset.txt      "$artifact_name"
 
-          echo ::set-output name=artifact_name::$artifact_name
+          echo ::set-output name=artifact_name::"$artifact_name"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.build.outputs.artifact_name }}
-          path: build/${{ steps.build.outputs.artifact_name }}
+          path: ${{ steps.build.outputs.artifact_name }}

--- a/.github/workflows/msx_ci_build.yml
+++ b/.github/workflows/msx_ci_build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add --no-cache musl-dev gcc vips-dev python3-dev zip py3-pip py3-wheel
+          apk add --no-cache musl-dev gcc vips-dev python3-dev py3-pip py3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
@@ -37,26 +37,24 @@ jobs:
       - name: Build
         id: build
         run: |
-          mkdir build && cd build
-          wget -q https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          mkdir build
+          wget -q -P build https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
           || echo "Error: Failed to get compose.py"
 
-          cd ..
-          python3 build/compose.py --use-all gfx/MShockXotto+
-          cd build
+          python3 build/compose.py --use-all gfx/MShockXotto+ build
 
-          artifact_name=MShockXotto+-$(echo $GITHUB_SHA | cut -c -8)
-          tileset_dir=../gfx/MShockXotto+
+          artifact_name=MShockXotto+-${GITHUB_SHA::7}
+          tileset_dir=build
 
-          mkdir $artifact_name
-          mv $tileset_dir/*.png            $artifact_name
-          mv $tileset_dir/tile_config.json $artifact_name
-          mv $tileset_dir/tileset.txt      $artifact_name
+          mkdir "$artifact_name"
+          mv $tileset_dir/*.png              "$artifact_name"
+          mv $tileset_dir/tile_config.json   "$artifact_name"
+          mv gfx/MShockXotto+/tileset.txt    "$artifact_name"
 
-          echo ::set-output name=artifact_name::$artifact_name
+          echo ::set-output name=artifact_name::"$artifact_name"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.build.outputs.artifact_name }}
-          path: build/${{ steps.build.outputs.artifact_name }}
+          path: ${{ steps.build.outputs.artifact_name }}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Infrastucture "Minor updates to composer scripts"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, Infrastructure.-->

#### Content of the change
Clean up composer scripts a bit, based on the edits I made to the cuteclysm composer 
<https://github.com/pixel-32/CDDA-tileset/blob/master/.github/workflows/ci_build.yml>

See comments `//` only found on this diff, explaining the rationale behind these changes.
```diff
diff --git a/.github/workflows/Chibi_ci_build.yml b/.github/workflows/Chibi_ci_build.yml
index d0124447..c6c56a63 100644
--- a/.github/workflows/Chibi_ci_build.yml
+++ b/.github/workflows/Chibi_ci_build.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          apk add --no-cache musl-dev gcc vips-dev python3-dev zip py3-pip py3-wheel
+          apk add --no-cache musl-dev gcc vips-dev python3-dev py3-pip py3-wheel
// zip package is not used anywhere, remove it. 
// Upload artifacts action already does some zip magic for us
           pip3 install pyvips
 
       - name: Checkout Code
@@ -59,26 +59,24 @@ jobs:
       - name: Build
         id: build
         run: |
-          mkdir build && cd build
-          wget -q https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          mkdir build
// Start of the eventual removal of unnecessary directory hopping.
// Make build directory, will be used to compose onto.
+          wget -q -P build https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
           || echo "Error: Failed to get compose.py"
// Tell wget to download compose.py inside the build directory.
 
-          cd ..
-          python3 build/compose.py --use-all gfx/Chibi_Ultica
-          cd build
+          python3 build/compose.py --use-all gfx/Chibi_Ultica build
// Compose a tileset drop results in the build directory.
 
-          artifact_name=Chibi_Ultica-$(echo $GITHUB_SHA | cut -c -8)
-          tileset_dir=../gfx/Chibi_Ultica
+          artifact_name=Chibi_Ultica-${GITHUB_SHA::7}
// Use github's standard 7 digit commit id for the name of the artifact
+          tileset_dir=build
 
-          mkdir $artifact_name
-          mv $tileset_dir/*.png            $artifact_name
-          mv $tileset_dir/tile_config.json $artifact_name
-          mv $tileset_dir/tileset.txt      $artifact_name
+          mkdir "$artifact_name"
+          mv $tileset_dir/*.png              "$artifact_name"
+          mv $tileset_dir/tile_config.json   "$artifact_name"
+          mv gfx/Chibi_Ultica/tileset.txt    "$artifact_name"
 
-          echo ::set-output name=artifact_name::$artifact_name
+          echo ::set-output name=artifact_name::"$artifact_name"
// Move stuff from build into the artifact directory. Why use double quotes when mentioning a variable? 
// shell check likes it, a static analysis tool for bash scripts https://github.com/koalaman/shellcheck
// TLDR: Prevents string funniness

       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
// why not
         with:
           name: ${{ steps.build.outputs.artifact_name }}
-          path: build/${{ steps.build.outputs.artifact_name }}
+          path: ${{ steps.build.outputs.artifact_name }}
// artifact directory is located at the root of the project, look there for a folder to upload

```
<!-- Explain what does this pull request contain. -->

#### Testing
This pr, CI.
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
